### PR TITLE
workflows/pr-check-rust.yaml: add dependency lib when do rust check

### DIFF
--- a/.github/workflows/pr-check-rust.yaml
+++ b/.github/workflows/pr-check-rust.yaml
@@ -21,6 +21,13 @@ jobs:
         with:
           toolchain: stable
 
+      - name: Install libtdx-attest
+        run: |
+          wget https://download.01.org/intel-sgx/sgx-dcap/1.16/linux/distro/ubuntu22.04-server/sgx_debian_local_repo.tgz
+          sudo mkdir -p /opt/intel/ && sudo tar zxf sgx_debian_local_repo.tgz -C /opt/intel/ 
+          sudo echo "deb [trusted=yes arch=amd64] file:/opt/intel/sgx_debian_local_repo jammy main" | sudo tee /etc/apt/sources.list.d/sgx_debian_local_repo.list
+          sudo apt update && yes | DEBIAN_FRONTEND=noninteractive sudo apt install -y libtdx-attest libtdx-attest-dev libcryptsetup-dev
+
       - name: Run cargo check
         run: |
           cd service/quote-server


### PR DESCRIPTION
the rust check will build the rust to a binary, 
so this PR will add the dependent libtdx-attest lib.

Signed-off-by: Hairong Chen hairong.chen@intel.com