### PR TITLE
workflows: update to use github hosted runner

### DIFF
--- a/.github/workflows/pr-container-check.yaml
+++ b/.github/workflows/pr-container-check.yaml
@@ -15,12 +15,8 @@ on:
 jobs:
   build_container:
     name: Build job for container
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     steps:
-      - name: Cleanup workspace for the job (self hosted only)
-        run: |
-          sudo rm -fr *
-
       - name: Checkout Code
         uses: actions/checkout@v3
 

--- a/.github/workflows/pr-license-python.yaml
+++ b/.github/workflows/pr-license-python.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   python-license-scan:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4


### PR DESCRIPTION
all none Intel or hardware dependent jobs should all run in GitHub hosted runner

Signed-off-by: Hairong Chen hairong.chen@intel.com