### PR TITLE
service/eventlog-server: add helm chart

### DIFF
--- a/chart/eventlog-server/Chart.yaml
+++ b/chart/eventlog-server/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: eventlog-server
+description: A Helm chart for Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "1.16.0"

--- a/chart/eventlog-server/templates/NOTES.txt
+++ b/chart/eventlog-server/templates/NOTES.txt
@@ -1,0 +1,18 @@
+{{- if .Values.service.enable}}
+1. Get the application URL by running these commands:
+{{- if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "eventlog-server.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "eventlog-server.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "eventlog-server.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "eventlog-server.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
+{{- end }}
+{{- end }}

--- a/chart/eventlog-server/templates/_helpers.tpl
+++ b/chart/eventlog-server/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "eventlog-server.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "eventlog-server.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "eventlog-server.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "eventlog-server.labels" -}}
+helm.sh/chart: {{ include "eventlog-server.chart" . }}
+{{ include "eventlog-server.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "eventlog-server.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "eventlog-server.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "eventlog-server.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "eventlog-server.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/chart/eventlog-server/templates/daemonset.yaml
+++ b/chart/eventlog-server/templates/daemonset.yaml
@@ -1,0 +1,103 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: {{ include "eventlog-server.fullname" . }}
+  namespace: {{ .Values.namespace }}
+  labels:
+    {{- include "eventlog-server.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "eventlog-server.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "eventlog-server.selectorLabels" . | nindent 8 }}
+    spec:
+      serviceAccountName: {{ include "eventlog-server.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      initContainers:
+        - name: change-permissions
+          image: busybox
+          command:
+            - sh
+            - -c
+            - >
+              chown -R 1000:1000 {{ .Values.volumes.eventlogDir }} &&
+              chmod 0744 {{ .Values.volumes.eventlogDir }} &&
+              chown -R 1000:1000 {{ .Values.volumes.sockDir }} &&
+              chmod 0744 {{ .Values.volumes.sockDir }} &&
+              chown 1000:1000 {{ .Values.volumes.eventlogEntryMount }} &&
+              chmod 0644 {{ .Values.volumes.eventlogEntryMount }} &&
+              chown 1000:1000 {{ .Values.volumes.eventlogDataMount }} &&
+              chmod 0644 {{ .Values.volumes.eventlogDataMount }}
+          volumeMounts:
+            - name: {{ .Values.volumes.eventlogVolume }}
+              mountPath: {{ .Values.volumes.eventlogDir }}
+            - name: {{ .Values.volumes.sockPath }}
+              mountPath: {{ .Values.volumes.sockDir }}
+            - name: {{ .Values.volumes.eventlogEntry }}
+              mountPath: {{ .Values.volumes.eventlogEntryMount }}
+            - name: {{ .Values.volumes.eventlogData }}
+              mountPath: {{ .Values.volumes.eventlogDataMount }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+    {{- if .Values.service.enable }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.port }}
+              protocol: TCP
+    {{- end }}
+          livenessProbe:
+            exec:
+                command: ["/usr/bin/grpc_health_probe", "-addr=unix:/run/ccnp/uds/eventlog.sock"]
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          readinessProbe:
+            exec:
+                command: ["/usr/bin/grpc_health_probe", "-addr=unix:/run/ccnp/uds/eventlog.sock"]
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            failureThreshold: 10
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+            - name: {{ .Values.volumes.eventlogVolume }}
+              mountPath: {{ .Values.volumes.eventlogDir }}
+            - name: {{ .Values.volumes.sockPath }}
+              mountPath: {{ .Values.volumes.sockDir }}
+            - name: {{ .Values.volumes.eventlogEntry }}
+              mountPath: {{ .Values.volumes.eventlogEntryMount }}
+            - name: {{ .Values.volumes.eventlogData }}
+              mountPath: {{ .Values.volumes.eventlogDataMount }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      volumes:
+      - name: {{ .Values.volumes.eventlogVolume }}
+        hostPath:
+          path: {{ .Values.volumes.eventlogDir }}
+          type: DirectoryOrCreate
+      - name: {{ .Values.volumes.sockPath }}
+        hostPath:
+          path: {{ .Values.volumes.sockDir }}
+          type: DirectoryOrCreate
+      - name: {{ .Values.volumes.eventlogData }}
+        hostPath:
+          path: {{ .Values.volumes.eventlogDataFile }}
+          type: File
+      - name: {{ .Values.volumes.eventlogEntry }}
+        hostPath:
+          path: {{ .Values.volumes.eventlogEntryFile }}
+          type: File
+

--- a/chart/eventlog-server/templates/namespace.yaml
+++ b/chart/eventlog-server/templates/namespace.yaml
@@ -1,0 +1,6 @@
+{{- if .Values.namespaceCreate }}
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ .Values.namespace }}
+{{- end}}

--- a/chart/eventlog-server/templates/serviceaccount.yaml
+++ b/chart/eventlog-server/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  namespace: {{ .Values.namespace }}
+  name: {{ include "eventlog-server.serviceAccountName" . }}
+  labels:
+    {{- include "eventlog-server.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/chart/eventlog-server/values.yaml
+++ b/chart/eventlog-server/values.yaml
@@ -1,0 +1,74 @@
+# Default values for get-eventlog.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+image:
+  repository: docker.io/library/ccnp_eventlog_server
+  pullPolicy: IfNotPresent
+  tag: "0.1"
+
+nameOverride: ""
+fullnameOverride: ""
+namespace: "ccnp"
+namespaceCreate: true
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+podAnnotations: {}
+
+podSecurityContext: {}
+  # fsGroup: 2000
+
+securityContext: {
+  runAsNonRoot: true
+}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsUser: 1000
+
+service:
+   enable: false
+#  type: ClusterIP
+#  port: 40084
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 100
+  targetCPUUtilizationPercentage: 80
+  # targetMemoryUtilizationPercentage: 80
+
+nodeSelector: {}
+
+volumes:
+  eventlogVolume: "eventlog-path"
+  eventlogDir: "/run/ccnp-eventlog"
+  eventlogEntry: "eventlog-entry"
+  eventlogEntryFile: "/sys/firmware/acpi/tables/CCEL"
+  eventlogEntryMount: "/run/firmware/acpi/tables/CCEL"
+  eventlogData: "eventlog-data"
+  eventlogDataFile: "/sys/firmware/acpi/tables/data/CCEL"
+  eventlogDataMount: "/run/firmware/acpi/tables/data/CCEL"
+  sockPath: "sock-path"
+  sockDir: "/run/ccnp/uds"


### PR DESCRIPTION
Add helm chart for the eventlog-server service for deployment, including such components:
- namespace
- daemonset
- serviceaccount

Skip service support for now, as we are using UDS for connection

resolves #20 