### PR TITLE
ccnp-device-plugin: add init container to detect TDX version

### DIFF
--- a/device-plugin/ccnp-device-plugin/deploy/helm/ccnp-device-plugin/templates/daemonset.yaml
+++ b/device-plugin/ccnp-device-plugin/deploy/helm/ccnp-device-plugin/templates/daemonset.yaml
@@ -29,7 +29,7 @@ spec:
           imagePullPolicy: IfNotPresent
           command: ['sh', '-c', \
                     "if [ -c /dev/tdx-guest ]; then touch /run/ccnp/dev/tdx-guest; \
-                    elif [ -c /dev/tdx_guest ]; then touch /run/ccnp/dev/tdx-guest; \
+                    elif [ -c /dev/tdx_guest ]; then touch /run/ccnp/dev/tdx_guest; \
                     elif [ -c /dev/tdx-attest ]; then touch /run/ccnp/dev/tdx-attest; \
                     else echo NO-DEVICE-ERROR; \
                     fi"]

--- a/device-plugin/ccnp-device-plugin/deploy/helm/ccnp-device-plugin/templates/daemonset.yaml
+++ b/device-plugin/ccnp-device-plugin/deploy/helm/ccnp-device-plugin/templates/daemonset.yaml
@@ -23,6 +23,21 @@ spec:
       serviceAccountName: {{ include "ccnp-device-plugin.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      initContainers:
+        - name: check-tdx-version
+          image: busybox
+          imagePullPolicy: IfNotPresent
+          command: ['sh', '-c', \
+                    "if [ -c /dev/tdx-guest ]; then touch /run/ccnp/dev/tdx-guest; \
+                    elif [ -c /dev/tdx_guest ]; then touch /run/ccnp/dev/tdx-guest; \
+                    elif [ -c /dev/tdx-attest ]; then touch /run/ccnp/dev/tdx-attest; \
+                    else echo NO-DEVICE-ERROR; \
+                    fi"]
+            volumeMounts:
+              - name: workdir
+                mountPath: /run/ccnp/dev/
+              - name: device-dir
+                mountPath: /dev
       containers:
         - name: {{ .Chart.Name }}
           securityContext:
@@ -34,8 +49,8 @@ spec:
           volumeMounts:
             - name: device-plugin
               mountPath: /var/lib/kubelet/device-plugins
-            - name: tdx-guest
-              mountPath: {{ .Values.tdxDevice }}
+            - name: workdir
+              mountPath: /run/ccnp/dev/
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -53,7 +68,9 @@ spec:
         hostPath:
           type: Directory
           path: /var/lib/kubelet/device-plugins
-      - name: tdx-guest
+      - name: workdir
+        emptyDir: {}
+      - name: device-dir
         hostPath:
-          path: {{ .Values.tdxDevice }}
-          type: CharDevice
+          type: Directory
+          path: /dev

--- a/device-plugin/ccnp-device-plugin/deploy/helm/ccnp-device-plugin/values.yaml
+++ b/device-plugin/ccnp-device-plugin/deploy/helm/ccnp-device-plugin/values.yaml
@@ -15,9 +15,6 @@ fullnameOverride: ""
 
 namespace: kube-system
 
-tdxDevice: /dev/tdx-guest
-
-
 serviceAccount:
   # Specifies whether a service account should be created
   create: true

--- a/device-plugin/ccnp-device-plugin/pkg/server/server.go
+++ b/device-plugin/ccnp-device-plugin/pkg/server/server.go
@@ -21,9 +21,11 @@ const (
 	DeviceType                 = "tdx-guest"
 	CcnpDpSocket               = "/var/lib/kubelet/device-plugins/ccnpdp.sock"
 	KubeletSocket              = "/var/lib/kubelet/device-plugins/kubelet.sock"
-	TDX_DEVICE_DEPRECATED      = "/dev/tdx-attest"
-	TDX_DEVICE_1_0             = "/dev/tdx-guest"
-	TDX_DEVICE_1_5             = "/dev/tdx_guest"
+	CHECK_DEVICE_DIR           = "/run/ccnp/dev/"
+	SYS_DEV_DIR                = "/dev/"
+	TDX_DEVICE_DEPRECATED      = "tdx-attest"
+	TDX_DEVICE_1_0             = "tdx-guest"
+	TDX_DEVICE_1_5             = "tdx_guest"
 	TdxDevicePermissions       = "rw"
 	MaxRestartCount            = 5
 	SocketConnectTimeout       = 5
@@ -53,17 +55,17 @@ func NewCcnpDpServer() *CcnpDpServer {
 
 func (ccnpdpsrv *CcnpDpServer) getTdxVersion() error {
 
-	if _, err := os.Stat(TDX_DEVICE_DEPRECATED); err == nil {
+	if _, err := os.Stat(CHECK_DEVICE_DIR + TDX_DEVICE_DEPRECATED); err == nil {
 		return errors.New("Deprecated TDX device found")
 	}
 
-	if _, err := os.Stat(TDX_DEVICE_1_0); err == nil {
-		ccnpdpsrv.tdxGuestDevice = TDX_DEVICE_1_0
+	if _, err := os.Stat(CHECK_DEVICE_DIR + TDX_DEVICE_1_0); err == nil {
+		ccnpdpsrv.tdxGuestDevice = SYS_DEV_DIR + TDX_DEVICE_1_0
 		return nil
 	}
 
-	if _, err := os.Stat(TDX_DEVICE_1_5); err == nil {
-		ccnpdpsrv.tdxGuestDevice = TDX_DEVICE_1_5
+	if _, err := os.Stat(CHECK_DEVICE_DIR + TDX_DEVICE_1_5); err == nil {
+		ccnpdpsrv.tdxGuestDevice = SYS_DEV_DIR + TDX_DEVICE_1_5
 		return nil
 	}
 


### PR DESCRIPTION
This PR will add an init container to detect the TDX version in runtime and let ccnp device plugin to register device node to Kubernetes accordingly

Signed-off-by: Hairong Chen hairong.chen@intel.com