### PR TITLE
action: add action to publish the CCNP to PyPI

### DIFF
--- a/.github/workflows/publish-ccnp.yaml
+++ b/.github/workflows/publish-ccnp.yaml
@@ -1,0 +1,25 @@
+name: Publish ccnp package to PyPI
+
+on:
+  workflow_dispatch:
+
+jobs:
+  publish_pypi:
+    name: Publish ccnp package
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v3
+
+      - name: Checkout action repository
+        uses: actions/checkout@v3
+
+      - name: Publish package
+        env:
+          PYPI_USERNAME: ${{ secrets.PYPI_USERNAME }}
+          PYPI_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+        run: |
+          python3 -m pip install --upgrade twine build wheel
+          cd sdk/python3
+          python3 -m build --wheel
+          python3 -m twine upload -u $PYPI_USERNAME -p $PYPI_PASSWORD --repository pypi dist/*

--- a/sdk/python3/.gitignore
+++ b/sdk/python3/.gitignore
@@ -1,2 +1,4 @@
 __pycache__
 *.egg-info
+build
+dist


### PR DESCRIPTION
This action will help to publish the CCNP project to pypi.org
https://pypi.org/manage/project/ccnp
