### PR TITLE
quote-server: use rust 1.70.0 as per required by rust deny

### DIFF
--- a/.github/workflows/pr-check-rust.yaml
+++ b/.github/workflows/pr-check-rust.yaml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up Rust action
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: 1.70.0
 
       - name: Install libtdx-attest
         run: |

--- a/.github/workflows/pr-check-rust.yaml
+++ b/.github/workflows/pr-check-rust.yaml
@@ -6,9 +6,11 @@ on:
       - main
     paths:
       - 'service/quote-server/**.rs'
+      - '.github/workflows/pr-check-rust.yaml'
   pull_request:
     paths:
       - 'service/quote-server/**.rs'
+      - '.github/workflows/pr-check-rust.yaml'
   workflow_dispatch:
 
 jobs:

--- a/service/quote-server/README.md
+++ b/service/quote-server/README.md
@@ -46,12 +46,12 @@ The quote service can be deployed as either DaemonSet or sidecar according to di
 The Dockerfile for the service can be found under `container/quote-server` directory. Use the following command to build the image:
 
 ```
-docker build -t ccnp-get-quote:0.1 -f container/quote-server/Dockerfile .
+docker build -t ccnp-quote-server:0.1 -f container/quote-server/Dockerfile .
 ```
 
 > Note: if you are using containerd as the default runtime for kubernetes, don't forget to use the following commands to import the image into containerd first:
 ```
-docker save -o ccnp-quote-server.tar ccnp-get-quote:0.1
+docker save -o ccnp-quote-server.tar ccnp-quote-server:0.1
 ctr -n=k8s.io image import ccnp-quote-server.tar
 ```
 


### PR DESCRIPTION
this PR contains fix for:

- pr-check-rust.yaml: use rust 1.70.0 as per required by rust deny
- README.md: fix image name

Signed-off-by: Hairong Chen hairong.chen@intel.com