### PR TITLE
quote-server: update nonce handling

### DIFF
--- a/service/quote-server/src/tee.rs
+++ b/service/quote-server/src/tee.rs
@@ -189,6 +189,22 @@ mod tests {
     }
 
     #[test]
+    //generate_tdx_report check result as expected
+    //original report_data = "abcdefgh", orginal nonce = "12345678"
+    fn generate_tdx_report_data_report_data_nonce_base64_encoded_as_expected() {
+        let result =
+            generate_tdx_report_data(Some("YWJjZGVmZw==".to_string()), "MTIzNDU2Nzg=".to_string())
+                .unwrap();
+        let expected_hash = [
+            250, 88, 93, 137, 200, 81, 221, 51, 138, 112, 220, 245, 53, 170, 42, 146, 254, 231,
+            131, 109, 214, 175, 241, 34, 101, 131, 232, 142, 9, 150, 41, 63, 22, 188, 0, 156, 101,
+            40, 38, 224, 252, 92, 112, 102, 149, 160, 60, 221, 206, 55, 47, 19, 158, 255, 77, 19,
+            149, 157, 166, 241, 245, 211, 234, 190,
+        ];
+        assert_eq!(result.d, expected_hash);
+    }
+
+    #[test]
     //generate_tdx_report allow long report data string
     fn generate_tdx_report_data_long_tdx_report_data() {
         let result = generate_tdx_report_data(

--- a/service/quote-server/src/tee.rs
+++ b/service/quote-server/src/tee.rs
@@ -174,10 +174,8 @@ mod tests {
     //generate_tdx_report require nonce string is base64 encoded
     fn generate_tdx_report_data_nonce_short_not_base64_encoded() {
         //coming in nonce should always be base64 encoded
-        let result = generate_tdx_report_data(
-            Some("IXUKoBO1XEFBPwopN4sY".to_string()),
-            "123".to_string(),
-        );
+        let result =
+            generate_tdx_report_data(Some("IXUKoBO1XEFBPwopN4sY".to_string()), "123".to_string());
         assert!(result.is_err());
     }
 
@@ -185,10 +183,8 @@ mod tests {
     //generate_tdx_report require report data string is base64 encoded
     fn generate_tdx_report_data_report_data_short_not_base64_encoded() {
         //coming in report data should always be base64 encoded
-        let result = generate_tdx_report_data(
-            Some("123".to_string()),
-            "IXUKoBO1XEFBPwopN4sY".to_string(),
-        );
+        let result =
+            generate_tdx_report_data(Some("123".to_string()), "IXUKoBO1XEFBPwopN4sY".to_string());
         assert!(result.is_err());
     }
 


### PR DESCRIPTION
coming in nonce string is base64 encoded to be sync with SDK, quote server will decode before use

Signed-off-by: Hairong Chen hairong.chen@intel.com
