### PR TITLE
quote-server: add support for helm deploy

### DIFF
--- a/container/quote-server/Dockerfile
+++ b/container/quote-server/Dockerfile
@@ -49,5 +49,5 @@ RUN apt-get -y clean && rm -rf /var/lib/apt/lists/*.
 COPY --from=quote-server-builder /quote-server/target/release/quote_server /bin
 COPY --from=quote-server-builder /grpc-health-probe/grpc-health-probe /usr/bin
 
-USER $USERNAME
+USER $USER_UID
 CMD ["/bin/quote_server"]

--- a/deployment/charts/quote-server/Chart.yaml
+++ b/deployment/charts/quote-server/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: quote-server
+description: A Helm chart for Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "1.16.0"

--- a/deployment/charts/quote-server/Chart.yaml
+++ b/deployment/charts/quote-server/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: quote-server
-description: A Helm chart for Kubernetes
+description: A Helm chart for CCNP quote server deployment in Kubernetes
 
 # A chart can be either an 'application' or a 'library' chart.
 #

--- a/deployment/charts/quote-server/templates/NOTES.txt
+++ b/deployment/charts/quote-server/templates/NOTES.txt
@@ -1,0 +1,18 @@
+{{- if .Values.service.enable }}
+1. Get the application URL by running these commands:
+{{- if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "quote-server.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "quote-server.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "quote-server.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "quote-server.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
+{{- end }}
+{{- end }}

--- a/deployment/charts/quote-server/templates/_helpers.tpl
+++ b/deployment/charts/quote-server/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "quote-server.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "quote-server.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "quote-server.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "quote-server.labels" -}}
+helm.sh/chart: {{ include "quote-server.chart" . }}
+{{ include "quote-server.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "quote-server.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "quote-server.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "quote-server.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "quote-server.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/deployment/charts/quote-server/templates/daemonset.yaml
+++ b/deployment/charts/quote-server/templates/daemonset.yaml
@@ -1,0 +1,56 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: {{ include "quote-server.fullname" . }}
+  namespace: {{ .Values.namespace }}
+  labels:
+    {{- include "quote-server.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "quote-server.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "quote-server.selectorLabels" . | nindent 8 }}
+    spec:
+      serviceAccountName: {{ include "quote-server.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+{{- if .Values.service.enable }}
+            ports:
+            - name: http
+              containerPort: {{ .Values.service.port }}
+              protocol: TCP
+{{- end }}
+          livenessProbe:
+            exec:
+              command: ["/usr/bin/grpc-health-probe", "-addr=unix:/run/ccnp/uds/quote-server.sock"]
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          readinessProbe:
+            exec:
+              command: ["/usr/bin/grpc-health-probe", "-addr=unix:/run/ccnp/uds/quote-server.sock"]
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            failureThreshold: 10
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/deployment/charts/quote-server/templates/namespace.yaml
+++ b/deployment/charts/quote-server/templates/namespace.yaml
@@ -1,0 +1,6 @@
+{{- if .Values.namespaceCreate }}
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ .Values.namespace }}
+{{- end }}

--- a/deployment/charts/quote-server/templates/serviceaccount.yaml
+++ b/deployment/charts/quote-server/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  namespace: {{ .Values.namespace }}
+  name: {{ include "quote-server.serviceAccountName" . }}
+  labels:
+    {{- include "quote-server.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/deployment/charts/quote-server/values.yaml
+++ b/deployment/charts/quote-server/values.yaml
@@ -1,0 +1,68 @@
+# Default values for quote server.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+image:
+  repository: docker.io/library/ccnp-quote-server
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: "0.1"
+
+nameOverride: ""
+fullnameOverride: ""
+namespace: ccnp
+namespaceCreate: false
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+podAnnotations: {}
+
+podSecurityContext: {}
+  # fsGroup: 2000
+
+securityContext: {
+  runAsNonRoot: true
+}
+
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+service:
+  enable: false
+  #  type: ClusterIP
+  #  port: 40083
+
+resources:
+  limits:
+    tdx.intel.com/tdx-guest: 1
+  requests:
+    tdx.intel.com/tdx-guest: 1
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+nodeSelector: {
+    "intel.feature.node.kubernetes.io/tdx-guest": "enabled"
+}
+
+tolerations: []
+
+affinity: {}

--- a/service/quote-server/README.md
+++ b/service/quote-server/README.md
@@ -56,6 +56,15 @@ ctr -n=k8s.io image import ccnp-quote-server.tar
 ```
 
 ### Deploy as DaemonSet in Kubernetes
+1. deploy using helm chart
+```
+cd deployment/
+# edit the value file for quote-server helm chart and run:
+helm install charts/quote-server --generate-name
+```
+
+2. deploy using manifests yaml file
+
 please check file `deployment/manifests/quote-server-deployment.yaml` to confirm the container image to use and run:
 ```
 kubectl apply -f deployment/manifests/quote-server-deployment.yaml


### PR DESCRIPTION
This PR includes changes for:
- add helm templates and configurations for quote server daemonset deployment
- update quote server readme to introduce helm deploy method

Signed-off-by: Hairong Chen hairong.chen@intel.com