### PR TITLE
quote-server: use ccnp as user to run quote server

### DIFF
--- a/container/quote-server/Dockerfile
+++ b/container/quote-server/Dockerfile
@@ -28,5 +28,5 @@ RUN addgroup -S -g $GID $GROUP \
 COPY --from=quote-server-builder /quote-server/target/release/quote_server /bin
 COPY --from=quote-server-builder /usr/bin/grpc-health-probe /usr/bin
 
-USER $USER_UID
+USER $UID
 CMD ["/bin/quote_server"]


### PR DESCRIPTION
this PR will update Dockerfile to use right USER ID to run quote server

Signed-off-by: Hairong Chen hairong.chen@intel.com