### PR TITLE
cvm-guest-rewriter: configure user login key

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,5 @@ tools/cvm-image-rewriter/cloud-init/meta-data
 tools/cvm-image-rewriter/cloud-init/user-data
 tools/cvm-image-rewriter/test.sh
 tools/cvm-image-rewriter/pre-stage/60-initrd-update/files/etc/initramfs-tools/hooks/initrd-custom-update.sh
+tools/cvm-image-rewriter/pre-stage/04-user-authkey/cloud-init/
 

--- a/tools/cvm-image-rewriter/pre-stage/04-user-authkey/host_run.sh
+++ b/tools/cvm-image-rewriter/pre-stage/04-user-authkey/host_run.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+# Go to this dir
+pushd "$(dirname "$(readlink -f "$0")")" || exit 0
+
+# shellcheck disable=SC1091
+source ../../scripts/common.sh
+
+# Check CVM_USER, CVM_AUTH_KEY
+CVM_USER="${CVM_USER:-cvm}"
+info "Config user: $CVM_USER"
+
+if [[ -z "$CVM_AUTH_KEY" ]]; then
+    warn "CVM_AUTH_KEY is not set, skip"
+    exit 0
+fi
+info "ssh pubkey: $CVM_AUTH_KEY"
+
+# Generate cloud-config
+mkdir -p cloud-init/cloud-config/
+cat > cloud-init/cloud-config/04-user-authkey.yaml << EOL
+#cloud-config
+merge_how:
+  - name: list
+    settings: [append]
+  - name: dict
+    settings: [no_replace, recurse_list]
+users:
+  - default
+  - name: $CVM_USER
+    groups: sudo
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    shell: /bin/bash
+    ssh_authorized_keys:
+      - $CVM_AUTH_KEY
+EOL
+
+popd || exit 0


### PR DESCRIPTION
Config ssh authorized key for user $CVM_USER.
By default password login is disabled.
When $CVM_AUTH_KEY is not set, this unit will not run.