### PR TITLE
eventlog-server-deployment.yaml: Add node selector

### DIFF
--- a/deployment/manifests/eventlog-server-deployment.yaml
+++ b/deployment/manifests/eventlog-server-deployment.yaml
@@ -113,3 +113,5 @@ spec:
         emptyDir: {}
       - name: eventlog-data-dir
         emptyDir: {}
+      nodeSelector:
+        intel.feature.node.kubernetes.io/tdx-guest: "enabled"


### PR DESCRIPTION
Add node selector to deploy eventlog server on TDX enabled node only