### PR TITLE
sdk/python/README.md: Update the example usage of quote SDK

### DIFF
--- a/sdk/python3/README.md
+++ b/sdk/python3/README.md
@@ -67,10 +67,11 @@ print(quote.quote)
 
 * Fetch quote with a `nonce`
 ```python
+import base64
 import secrets
 from ccnp import Quote
 
-nonce = secrets.token_urlsafe()
+nonce = base64.b64encode(secrets.token_urlsafe().encode())
 quote = Quote.get_quote(nonce=nonce)
 
 print(quote.quote_type)
@@ -84,7 +85,7 @@ import base64
 import secrets
 from ccnp import Quote
 
-nonce = secrets.token_urlsafe()
+nonce = base64.b64encode(secrets.token_urlsafe().encode())
 user_data = base64.b64encode(b'This data should be measured.')
 quote = Quote.get_quote(nonce=nonce, user_data=user_data)
 


### PR DESCRIPTION
Update the example usage of quote SDK，otherwise it will cause failure to get quote：
`details = "[get_tdx_quote]: [generate_tdx_report_data] nonce is not base64 encoded: InvalidByte(23, 45)"`