### PR TITLE
Doc: add OpenSSF badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 ![CI Check Golang](https://github.com/intel/confidential-cloud-native-primitives/actions/workflows/pr-golang-check.yaml/badge.svg)
 ![CI Check Container](https://github.com/intel/confidential-cloud-native-primitives/actions/workflows/pr-container-check.yaml/badge.svg)
 ![CC Foundation Image Customize](https://github.com/intel/confidential-cloud-native-primitives/actions/workflows/image-rewriter.yaml/badge.svg)
+[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/8325/badge)](https://www.bestpractices.dev/projects/8325)
 
 ## 1. Introduction
 


### PR DESCRIPTION
To align with CII-Best-Practices in OpenSSF, register the project and adding badge for it.
