### PR TITLE
Update qemu-test.sh

### DIFF
--- a/tools/cvm-image-rewriter/qemu-test.sh
+++ b/tools/cvm-image-rewriter/qemu-test.sh
@@ -219,7 +219,7 @@ process_args() {
             # Note: "pic=no" could only be used in TD mode but not for non-TD mode
             PARAM_MACHINE+=",kernel_irqchip=split,memory-encryption=tdx,memory-backend=ram1"
             QEMU_CMD+=" -bios ${OVMF}"
-            QEMU_CMD+=" -object tdx-guest,sept-ve-disable,id=tdx"
+            QEMU_CMD+=" -object tdx-guest,sept-ve-disable=on,id=tdx"
             if [[ ${QUOTE_TYPE} == "tdvmcall" ]]; then
                 QEMU_CMD+=",quote-generation-service=vsock:2:4050"
             fi
@@ -229,7 +229,7 @@ process_args() {
             if [[ ${DEBUG} == true ]]; then
                 QEMU_CMD+=",debug=on"
             fi
-	    QEMU_CMD+=" -object memory-backend-ram,id=ram1,size=${MEM},private=on"
+	    QEMU_CMD+=" -object memory-backend-ram,id=ram1,size=${MEM}"
             ;;
         "efi")
             PARAM_MACHINE+=",kernel_irqchip=split"


### PR DESCRIPTION
QEMU command line update:

- change sept-ve-disable to sept-ve-disable=on, sept-ve-disable short form is depracated 

- delete private=on, private=on is not recognizable in qemu 7.0 with tdx-1.0 patches