### PR TITLE
optimize the image size of pod-quote and add unit test for pod-quote

### DIFF
--- a/container/pod-quote/Dockerfile
+++ b/container/pod-quote/Dockerfile
@@ -2,12 +2,8 @@ FROM rust:1.74.0 as pod-quote-builder
 
 RUN apt-get update && apt-get install -y \
     build-essential \
-    curl \
-    make \
     libprotobuf-dev \
     protobuf-compiler \
-    musl-dev \
-    wget \
     libssl-dev \
     pkg-config
 
@@ -19,7 +15,9 @@ COPY service/pod-quote /pod-quote
 
 RUN cd /pod-quote && make build
 
-FROM rust:1.74.0
+FROM rust:1.74.0-slim
+
+RUN apt-get update && apt-get install -y curl
 
 WORKDIR /app
 COPY --from=pod-quote-builder /pod-quote/target/release/pod_quote /app/pod_quote


### PR DESCRIPTION
There are major 2 changes for this PR:
1. Reduce the image size of pod-quote. The image size of `ccnp-pod-quote` is reduced from `1.5G` to `854MB`
2. Add the unit test for pod-quote http server